### PR TITLE
lumpを削除するためのDeleteコマンドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,57 @@
 # Watari Kani (or, Gazami Crab)
 Remote version of [KaniLS](https://github.com/frugalos/kanils) based on [Cannyls_rpc](https://github.com/frugalos/cannyls_rpc)
 
+# Available Commands
 ## List
-`./watarikani List --addr 127.0.0.1:14278 --device file_0`
-
+Using the command `List`, we can obtain the list of all the lump ids in the given device `device`.
 ```
-listed.len() = 294
-LumpId("00000000000108000000000000000000")
-LumpId("00000000000108010000000000000015")
+$ watarikani List --rpc-addr 127.0.0.1:14278 --device file0
+listed.len() = 24
+LumpId("00000000000000000000000000000000")
+LumpId("00000000000000010000000000000000")
 ...
-LumpId("0100000000070600000000000000000d")
-LumpId("0100000000070600000000000000000e")
+LumpId("01000000000100000000000000000001")
+LumpId("01000000000101000000000000000001")
+LumpId("01000000000102000000000000000001")
 ```
 
 ## Head
-`./watarikani Head --addr 127.0.0.1:14278 --device file_0 --lumpid 0100000000070600000000000000000e`
-
+Using the command `Head`, we can check if the given lump id belongs to the given device.
 ```
+$ watarikani Head --rpc-addr 127.0.0.1:14278 --device file0 --lumpid 01000000000101000000000000000001
 LumpHeader { approximate_data_size: 33280 }
+
+$ watarikani Head --rpc-addr 127.0.0.1:14278 --device file0 --lumpid 01000000000101000000000000000002
+LumpId("01000000000101000000000000000002") does not exist
 ```
 
-`./watarikani Head --addr 127.0.0.1:14278 --device file_0 --lumpid 0100000000070600000000000000000f`
-
+## Get
+Using the command `Get`, we can get the content of the given lump id if it belongs to the given device.
 ```
-LumpId("0100000000070600000000000000000f") does not exist
+$ watarikani Get --rpc-addr 127.0.0.1:14278 --device file_0 --lumpid 0100000000070600000000000000000e
+[2, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0,
+ 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 2, 0, 204, 94,
+12, 11, 0, 5, 1, 0, 80, 142, 138, 88, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+121, 111, 117, 114, 95, 111, 98, 106, 101, 99, 116, 95, 100, 97,
+116, 97, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... (omitted)
+
+$ watarikani Get --rpc-addr 127.0.0.1:14278 --device file0 --lumpid 01000000000101000000000000000002
+LumpId("01000000000101000000000000000002") does not exist
+```
+
+## Delete
+Using the command `Delete`, we can delete the given lump id if it belongs to the given device.
+```
+$ watarikani Delete --rpc-addr 127.0.0.1:14278 --device file0 --lumpid 01000000000101000000000000000001
+Removed LumpId("01000000000101000000000000000001")
+
+$ watarikani List --rpc-addr 127.0.0.1:14278 --device file0
+listed.len() = 23
+LumpId("00000000000000000000000000000000")
+LumpId("00000000000000010000000000000000")
+LumpId("00000000000001000000000000000000")
+...
+LumpId("01000000000100000000000000000001")
+LumpId("01000000000102000000000000000001")
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use fibers::{Executor, InPlaceExecutor, Spawn};
 use fibers_rpc::client::ClientService;
 use futures::{Async, Future};
 use std::net::SocketAddr;
+use std::str::FromStr;
 use std::thread;
 use structopt::StructOpt;
 
@@ -31,10 +32,6 @@ macro_rules! wait {
 
 fn to_device_id(d: &str) -> DeviceId {
     DeviceId::new(d)
-}
-
-fn str_to_u128(lumpid_str: &str) -> u128 {
-    u128::from_str_radix(lumpid_str, 16).unwrap()
 }
 
 arg_enum! {
@@ -57,14 +54,14 @@ struct Opt {
     device_id: String,
 
     #[structopt(long = "lumpid")]
-    lumpid: Option<String>,
+    lump_id: Option<String>,
 
     #[structopt(raw(
         possible_values = "&Command::variants()",
         requires_ifs = r#"&[
-("Get", "lumpid"),
-("Head", "lumpid"),
-("Delete", "lumpid"),
+("Get", "lump_id"),
+("Head", "lump_id"),
+("Delete", "lump_id"),
 ]"#
     ))]
     command: Command,
@@ -99,33 +96,30 @@ fn main() {
             }
         }
         Command::Get => {
-            let lumpid = str_to_u128(&opt.lumpid.unwrap());
-            let lumpid = LumpId::new(lumpid);
-            let object = wait!(request.get_lump(device_id, lumpid));
+            let lump_id = LumpId::from_str(&opt.lump_id.unwrap()).unwrap();
+            let object = wait!(request.get_lump(device_id, lump_id));
             if let Some(data) = object {
                 println!("{:?}", data);
             } else {
-                println!("{:?} does not exist", lumpid);
+                println!("{:?} does not exist", lump_id);
             }
         }
         Command::Head => {
-            let lumpid = str_to_u128(&opt.lumpid.unwrap());
-            let lumpid = LumpId::new(lumpid);
-            let info = wait!(request.head_lump(device_id, lumpid));
+            let lump_id = LumpId::from_str(&opt.lump_id.unwrap()).unwrap();
+            let info = wait!(request.head_lump(device_id, lump_id));
             if let Some(data) = info {
                 println!("{:?}", data);
             } else {
-                println!("{:?} does not exist", lumpid);
+                println!("{:?} does not exist", lump_id);
             }
         }
         Command::Delete => {
-            let lumpid = str_to_u128(&opt.lumpid.unwrap());
-            let lumpid = LumpId::new(lumpid);
-            let removed = wait!(request.delete_lump(device_id, lumpid));
+            let lump_id = LumpId::from_str(&opt.lump_id.unwrap()).unwrap();
+            let removed = wait!(request.delete_lump(device_id, lump_id));
             if removed {
-                println!("Removed {:?}", lumpid);
+                println!("Removed {:?}", lump_id);
             } else {
-                println!("There is no {:?}", lumpid);
+                println!("There is no {:?}", lump_id);
             }
         }
     }


### PR DESCRIPTION
# PRの要約
watarikaniを用いて起動中のfrugalosインスタンスの抱えているlusf中のlumpオブジェクトを削除できるようにする。

# 使い方
```
/target/debug/watarikani Delete --rpc-addr 127.0.0.1:14278 --device file0 --lumpid 0x01000000000100000000000000000001
```

# 例
```
./target/debug/watarikani List --device file0
listed.len() = 24
LumpId("00000000000000000000000000000000")
LumpId("00000000000000010000000000000000")
LumpId("00000000000001000000000000000000")
...
LumpId("00000000000202000000000000000000")
LumpId("00000000000202010000000000000000")
LumpId("01000000000100000000000000000001")
LumpId("01000000000101000000000000000001")
LumpId("01000000000102000000000000000001")
```

```
./target/debug/watarikani Delete --device file0 --lumpid 01000000000100000000000000000001
# rpc-addrオプションを省略した場合は、127.0.0.1:14278に対してRPCを行う
Removed LumpId("01000000000100000000000000000001")
```

```
$ ./target/debug/watarikani List --device file0
listed.len() = 23
LumpId("00000000000000000000000000000000")
LumpId("00000000000000010000000000000000")
LumpId("00000000000001000000000000000000")
...
LumpId("00000000000202000000000000000000")
LumpId("00000000000202010000000000000000")
LumpId("01000000000101000000000000000001")
LumpId("01000000000102000000000000000001")
```